### PR TITLE
Introduce user migration feature

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,12 @@
             <artifactId>hutool-all</artifactId>
             <version>5.8.18</version>
         </dependency>
-    </dependencies>
+        <dependency>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
+            <version>8.0.33</version>
+        </dependency>
+      </dependencies>
 
     <build>
         <plugins>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,15 +1,9 @@
-spring.datasource.url=jdbc:h2:mem:testdb
-spring.datasource.driverClassName=org.h2.Driver
-spring.datasource.username=sa
-spring.datasource.password=
-
-#spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
-#spring.jpa.defer-datasource-initialization=true
-
-#spring.sql.init.mode=always
+spring.datasource.url=jdbc:mysql://localhost:3306/test?allowMultiQueries=true
+spring.datasource.driverClassName=com.mysql.cj.jdbc.Driver
+spring.datasource.username=root
+spring.datasource.password=root
 
 spring.jpa.show-sql=true
-spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.H2Dialect
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect
 spring.jpa.hibernate.ddl-auto= update
 
-spring.h2.console.enabled=true


### PR DESCRIPTION
This pull request introduces support for MySQL as the application's database, replacing the previous H2 in-memory database. It updates the project dependencies, configuration, and introduces a new user migration endpoint that leverages direct JDBC connection management for transactional consistency during migrations.

**Database migration to MySQL:**

* Updated the `pom.xml` to add the `mysql-connector-j` dependency, enabling MySQL connectivity.
* Changed `application.properties` to configure the datasource for MySQL, including URL, driver, credentials, and Hibernate dialect. The previous H2 configuration was removed.

**User migration endpoint and JDBC usage:**

* Added a new `/user/migrate` POST endpoint in `UserController` to migrate user data, using a transactional approach with JDBC savepoints for rollback on failure.
* Introduced direct JDBC connection handling in `UserController` via a new `getConnection()` method, which unwraps the Hibernate session to obtain a `ConnectionImpl`.
* Injected `EntityManager` into `UserController` to facilitate access to the underlying JDBC connection.

**Imports and dependencies:**

* Added necessary imports for JDBC, concurrency, and JPA in `UserController.java` to support the new migration logic and database connectivity. [[1]](diffhunk://#diff-3c9d66f0223bb4fbb5839e31cd18f91cda953db37cce8ee44a181e073a2c88ddR10-R11) [[2]](diffhunk://#diff-3c9d66f0223bb4fbb5839e31cd18f91cda953db37cce8ee44a181e073a2c88ddR30-R33)