### PR TITLE
Allow the import of users

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,6 +81,11 @@
             <artifactId>hutool-all</artifactId>
             <version>5.8.18</version>
         </dependency>
+        <dependency>
+            <groupId>com.glazedlists</groupId>
+            <artifactId>glazedlists</artifactId>
+            <version>1.11.0</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/com/dashboardmanager/controller/UserController.java
+++ b/src/main/java/com/dashboardmanager/controller/UserController.java
@@ -1,5 +1,6 @@
 package com.dashboardmanager.controller;
 
+import ca.odell.glazedlists.impl.io.BeanXMLByteCoder;
 import cn.hutool.cache.file.LRUFileCache;
 import com.dashboardmanager.model.Session;
 import com.dashboardmanager.model.User;
@@ -16,6 +17,7 @@ import org.springframework.core.io.Resource;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -25,6 +27,7 @@ import org.springframework.web.servlet.view.RedirectView;
 
 import java.io.*;
 import java.security.SecureRandom;
+import java.util.List;
 
 import static org.apache.commons.codec.binary.Base64.decodeBase64;
 
@@ -103,6 +106,18 @@ public class UserController {
         }
     }
 
+    @PostMapping("/user/import")
+    public ResponseEntity<Resource> importUsers(HttpServletRequest request) {
+        var coder = new BeanXMLByteCoder();
+        List<User> newUsers;
+        try {
+             newUsers = (List<User>) coder.decode(request.getInputStream());
+        } catch (IOException e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
+        }
+        usersRepository.saveAll(newUsers);
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+    }
 
     private String createSessionHeader(Session session) {
         SessionHeader sessionHeader = new SessionHeader(session.getUser().getName(), session.getSessionId());


### PR DESCRIPTION
This pull request introduces a new user import feature to the `UserController`, allowing bulk import of users via XML, and adds the required dependency for XML deserialization. The main changes are grouped into new feature implementation and dependency management.

**New Feature: User Import Endpoint**
- Added a new `POST /user/import` endpoint in `UserController` that accepts an XML payload of users, decodes it using `BeanXMLByteCoder`, and saves the users to the repository. Returns `400 Bad Request` on decode failure and `204 No Content` on success.

**Dependency Management**
- Added the `glazedlists` library (version 1.11.0) to `pom.xml` to provide the `BeanXMLByteCoder` needed for XML deserialization.

**Imports and Housekeeping**
- Imported `BeanXMLByteCoder` and related classes in `UserController.java` to support the new import functionality. [[1]](diffhunk://#diff-3c9d66f0223bb4fbb5839e31cd18f91cda953db37cce8ee44a181e073a2c88ddR3) [[2]](diffhunk://#diff-3c9d66f0223bb4fbb5839e31cd18f91cda953db37cce8ee44a181e073a2c88ddR20) [[3]](diffhunk://#diff-3c9d66f0223bb4fbb5839e31cd18f91cda953db37cce8ee44a181e073a2c88ddR30)